### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
         default: "yarn build"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 permissions:
   contents: read
 
@@ -25,3 +29,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: ${{ inputs.script || 'yarn build' }}
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: "yarn"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -32,6 +36,7 @@ jobs:
       base_branch: ${{ inputs.base_branch || 'main' }}
       script: ${{ inputs.script || 'yarn build' }}
       package_manager: ${{ inputs.package_manager || 'yarn' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: "yarn"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
   pull_request:
     types: [opened, synchronize, labeled]
@@ -42,3 +46,4 @@ jobs:
       mode: ${{ github.event_name == 'pull_request' && 'verify' || inputs.mode }}
       script: ${{ inputs.script || 'yarn build' }}
       package_manager: ${{ inputs.package_manager || 'yarn' }}
+      node_version: "${{ inputs.node_version || '24' }}"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 <img align="right" src="https://upload.wikimedia.org/wikipedia/commons/f/f8/YAML_Logo.svg" width=150></img>
 # Read YAML
 

--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ output:
     description: 'Data read from YAML file'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29,107 +29,64 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
-var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
-    function verb(n) { return function (v) { return step([n, v]); }; }
-    function step(op) {
-        if (f) throw new TypeError("Generator is already executing.");
-        while (g && (g = 0, op[0] && (_ = 0)), _) try {
-            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
-            if (y = 0, t) op = [op[0] & 2, t.value];
-            switch (op[0]) {
-                case 0: case 1: t = op; break;
-                case 4: _.label++; return { value: op[1], done: false };
-                case 5: _.label++; y = op[1]; op = [0]; continue;
-                case 7: op = _.ops.pop(); _.trys.pop(); continue;
-                default:
-                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
-                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
-                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
-                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
-                    if (t[2]) _.ops.pop();
-                    _.trys.pop(); continue;
-            }
-            op = body.call(thisArg, _);
-        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
-        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+const core = __importStar(__nccwpck_require__(2186));
+const fs = __importStar(__nccwpck_require__(7147));
+const yaml = __importStar(__nccwpck_require__(1917));
+const axios_1 = __importStar(__nccwpck_require__(8757));
+async function validateSubscription() {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    let repoPrivate;
+    if (eventPath && fs.existsSync(eventPath)) {
+        const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+        repoPrivate = eventData?.repository?.private;
+    }
+    const upstream = 'jbutcher5/read-yaml';
+    const action = process.env.GITHUB_ACTION_REPOSITORY;
+    const docsUrl = 'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+    core.info('');
+    core.info('[1;36mStepSecurity Maintained Action[0m');
+    core.info(`Secure drop-in replacement for ${upstream}`);
+    if (repoPrivate === false)
+        core.info('[32m✓ Free for public repositories[0m');
+    core.info(`[36mLearn more:[0m ${docsUrl}`);
+    core.info('');
+    if (repoPrivate === false)
+        return;
+    const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+    const body = { action: action || '' };
+    if (serverUrl !== 'https://github.com')
+        body.ghes_server = serverUrl;
+    try {
+        await axios_1.default.post(`https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`, body, { timeout: 3000 });
+    }
+    catch (error) {
+        if ((0, axios_1.isAxiosError)(error) && error.response?.status === 403) {
+            core.error(`[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`);
+            core.error(`[31mLearn how to enable a subscription: ${docsUrl}[0m`);
+            process.exit(1);
+        }
+        core.info('Timeout or API not reachable. Continuing to next step.');
+    }
+}
+const run = async () => {
+    try {
+        await validateSubscription();
+        const file = core.getInput('file');
+        const keys = JSON.parse(core.getInput('key-path'));
+        const content = await fs.promises.readFile(file, 'utf8');
+        let yamlData = yaml.load(content);
+        if (yamlData == null || yamlData == undefined) {
+            core.setFailed('Error in reading the yaml file');
+            return;
+        }
+        let output = keys.reduce((dict, key) => dict[key], yamlData);
+        core.setOutput('data', output);
+    }
+    catch (error) {
+        core.setFailed(error.message);
     }
 };
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-var core = __importStar(__nccwpck_require__(2186));
-var fs_1 = __nccwpck_require__(7147);
-var yaml = __importStar(__nccwpck_require__(1917));
-var axios_1 = __importStar(__nccwpck_require__(8757));
-function validateSubscription() {
-    var _a;
-    return __awaiter(this, void 0, void 0, function () {
-        var API_URL, error_1;
-        return __generator(this, function (_b) {
-            switch (_b.label) {
-                case 0:
-                    API_URL = "https://agent.api.stepsecurity.io/v1/github/".concat(process.env.GITHUB_REPOSITORY, "/actions/subscription");
-                    _b.label = 1;
-                case 1:
-                    _b.trys.push([1, 3, , 4]);
-                    return [4 /*yield*/, axios_1.default.get(API_URL, { timeout: 3000 })];
-                case 2:
-                    _b.sent();
-                    return [3 /*break*/, 4];
-                case 3:
-                    error_1 = _b.sent();
-                    if ((0, axios_1.isAxiosError)(error_1) && ((_a = error_1.response) === null || _a === void 0 ? void 0 : _a.status) === 403) {
-                        core.error('Subscription is not valid. Reach out to support@stepsecurity.io');
-                        process.exit(1);
-                    }
-                    else {
-                        core.info('Timeout or API not reachable. Continuing to next step.');
-                    }
-                    return [3 /*break*/, 4];
-                case 4: return [2 /*return*/];
-            }
-        });
-    });
-}
-var run = function () { return __awaiter(void 0, void 0, void 0, function () {
-    var file, keys, content, yamlData, output, error_2;
-    return __generator(this, function (_a) {
-        switch (_a.label) {
-            case 0:
-                _a.trys.push([0, 3, , 4]);
-                return [4 /*yield*/, validateSubscription()];
-            case 1:
-                _a.sent();
-                file = core.getInput('file');
-                keys = JSON.parse(core.getInput('key-path'));
-                return [4 /*yield*/, fs_1.promises.readFile(file, 'utf8')];
-            case 2:
-                content = _a.sent();
-                yamlData = yaml.load(content);
-                if (yamlData == null || yamlData == undefined) {
-                    core.setFailed('Error in reading the yaml file');
-                    return [2 /*return*/];
-                }
-                output = keys.reduce(function (dict, key) { return dict[key]; }, yamlData);
-                core.setOutput('data', output);
-                return [3 /*break*/, 4];
-            case 3:
-                error_2 = _a.sent();
-                core.setFailed(error_2.message);
-                return [3 /*break*/, 4];
-            case 4: return [2 /*return*/];
-        }
-    });
-}); };
 run();
 //# sourceMappingURL=index.js.map
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,52 @@
 import * as core from '@actions/core'
-import { promises as fs } from 'fs'
+import * as fs from 'fs'
 import * as yaml from 'js-yaml'
 import axios, { isAxiosError } from 'axios'
 
 async function validateSubscription(): Promise<void> {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  let repoPrivate: boolean | undefined
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+    repoPrivate = eventData?.repository?.private
+  }
+
+  const upstream = 'jbutcher5/read-yaml'
+  const action = process.env.GITHUB_ACTION_REPOSITORY
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+
+  core.info('')
+  core.info('[1;36mStepSecurity Maintained Action[0m')
+  core.info(`Secure drop-in replacement for ${upstream}`)
+  if (repoPrivate === false)
+    core.info('[32m✓ Free for public repositories[0m')
+  core.info(`[36mLearn more:[0m ${docsUrl}`)
+  core.info('')
+
+  if (repoPrivate === false) return
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const body: Record<string, string> = {action: action || ''}
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl
   try {
-    await axios.get(API_URL, {timeout: 3000});
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    )
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
-      core.error('Subscription is not valid. Reach out to support@stepsecurity.io');
-      process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
+      core.error(
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`
+      )
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`
+      )
+      process.exit(1)
     }
+    core.info('Timeout or API not reachable. Continuing to next step.')
   }
 }
 
@@ -24,7 +56,7 @@ const run = async () => {
         const file = core.getInput('file')
         const keys: string[] = JSON.parse(core.getInput('key-path'))
 
-        const content = await fs.readFile(file, 'utf8')
+        const content = await fs.promises.readFile(file, 'utf8')
 
         let yamlData = yaml.load(content) as Record<string, any>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2022",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24
- Updated workflow files with configurable node_version input
- Rebuilt dist/ to include new validateSubscription

## Changes
- Replaced `validateSubscription()` body in `src/index.ts` (upstream: jbutcher5/read-yaml)
- Updated `action.yml` to `node24`
- Added `node_version` input to actions_release.yml, audit_package.yml, auto_cherry_pick.yml
- Added banner to top of README.md

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [x] Build passes

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z